### PR TITLE
Add <QDir> include

### DIFF
--- a/src/VM.cpp
+++ b/src/VM.cpp
@@ -24,6 +24,7 @@
 #include <QList>
 #include <QObject>
 #include <QString>
+#include <QDir>
 #include <QFile>
 #include <QFileInfo>
 #include <QTextStream>


### PR DESCRIPTION
This include should have been added in 0313d34 but was not. This omission causes the build to fail with Qt 5.2.1.