### PR TITLE
Macos build fix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -198,6 +198,8 @@ FIND_PACKAGE( Qt5Test )
 FIND_PACKAGE( Qt5PrintSupport )
 FIND_PACKAGE( Qt5DBus )
 
+include_directories(/usr/local/opt/libvncserver/include)
+
 # Embedded VNC display
 IF( NOT WITHOUT_EMBEDDED_DISPLAY )
 	FIND_PACKAGE( LibVNCServer REQUIRED )

--- a/src/Embedded_Display/vncclientthread.cpp
+++ b/src/Embedded_Display/vncclientthread.cpp
@@ -32,6 +32,12 @@
 #include <QMutexLocker>
 #include <QThreadStorage>
 #include <QTimer>
+#if !defined(SOL_TCP) && defined(IPPROTO_TCP)
+#define SOL_TCP IPPROTO_TCP
+#endif
+#if !defined(TCP_KEEPIDLE) && defined(TCP_KEEPALIVE)
+#define TCP_KEEPIDLE TCP_KEEPALIVE
+#endif
 
 //for detecting intel AMT KVM vnc server
 static const QString INTEL_AMT_KVM_STRING= QLatin1String("Intel(r) AMT KVM");


### PR DESCRIPTION
These are the minimal changes required to make it work on macOS 10.14.6 (Mojave).

The CMakeLists.txt change might be clumsy, I don't really know CMake but it was the only way I found to find the includes at compile time. If there is a better way, I'm happy to amend it.

For the record, I wrote down the build setup here: https://github.com/toyg/aqemu/wiki/Build-on-macOS . I can save it in a README.macos and push that too, if you want.