### PR TITLE
Fix crash because of duplicated widget name

### DIFF
--- a/src/Advanced_Settings_Window.ui
+++ b/src/Advanced_Settings_Window.ui
@@ -2220,7 +2220,7 @@ Supports only USB &amp;1.1 controller emulation.</string>
            </property>
            <layout class="QHBoxLayout" name="horizontalLayout_25">
             <item>
-             <widget class="QWidget" name="widget" native="true">
+             <widget class="QWidget" name="widget_3" native="true">
               <layout class="QVBoxLayout" name="verticalLayout_16">
                <property name="leftMargin">
                 <number>10</number>

--- a/src/Create_Template_Window.ui
+++ b/src/Create_Template_Window.ui
@@ -167,7 +167,7 @@
     </spacer>
    </item>
    <item>
-    <widget class="QGroupBox" name="groupBox">
+    <widget class="QGroupBox" name="groupBox_2">
      <property name="title">
       <string>Options</string>
      </property>
@@ -230,7 +230,7 @@
     </widget>
    </item>
    <item>
-    <layout class="QHBoxLayout">
+    <layout class="QHBoxLayout" name="hboxLayout">
      <property name="spacing">
       <number>6</number>
      </property>
@@ -247,7 +247,7 @@
       <number>0</number>
      </property>
      <item>
-      <spacer>
+      <spacer name="spacer">
        <property name="orientation">
         <enum>Qt::Horizontal</enum>
        </property>

--- a/src/Main_Window.ui
+++ b/src/Main_Window.ui
@@ -2457,7 +2457,7 @@
                     </layout>
                    </item>
                    <item row="1" column="0" colspan="2">
-                    <widget class="QWidget" name="widget" native="true">
+                    <widget class="QWidget" name="widget_2" native="true">
                      <layout class="QHBoxLayout" name="Widget_Redirection_Protocol">
                       <property name="spacing">
                        <number>6</number>
@@ -2515,7 +2515,7 @@
                     </widget>
                    </item>
                    <item row="2" column="0" colspan="2">
-                    <widget class="QWidget" name="widget" native="true">
+                    <widget class="QWidget" name="widget_3" native="true">
                      <layout class="QHBoxLayout" name="Widget_Redirection_Net">
                       <property name="spacing">
                        <number>6</number>

--- a/src/SPICE_Settings_Widget.ui
+++ b/src/SPICE_Settings_Widget.ui
@@ -209,7 +209,7 @@
            </widget>
           </item>
           <item>
-           <widget class="QGroupBox" name="groupBox">
+           <widget class="QGroupBox" name="groupBox_2">
             <property name="title">
              <string>Image, Video and Audio</string>
             </property>
@@ -387,7 +387,7 @@
            </widget>
           </item>
           <item>
-           <widget class="QGroupBox" name="groupBox">
+           <widget class="QGroupBox" name="groupBox_3">
             <property name="title">
              <string>Security</string>
             </property>

--- a/src/Settings_Window.ui
+++ b/src/Settings_Window.ui
@@ -121,7 +121,7 @@
     </spacer>
    </item>
    <item>
-    <widget class="QGroupBox" name="groupBox">
+    <widget class="QGroupBox" name="groupBox_2">
      <property name="title">
       <string>User Interface</string>
      </property>
@@ -288,7 +288,7 @@
     </spacer>
    </item>
    <item>
-    <widget class="QGroupBox" name="groupBox">
+    <widget class="QGroupBox" name="groupBox_3">
      <property name="title">
       <string>Virtual Machine User Interface</string>
      </property>


### PR DESCRIPTION
This was causing bad header generation from ui files with Qt 5.15 were setupUi was trying to call widget2->raise() before setting widget2 variable (for Main_Window.ui case).