### PR TITLE
Replace "info kqemu" command with "info kvm"

### DIFF
--- a/src/Monitor_Window.ui
+++ b/src/Monitor_Window.ui
@@ -198,7 +198,7 @@
        </item>
        <item>
         <property name="text">
-         <string>info kqemu</string>
+         <string>info kvm</string>
         </property>
        </item>
        <item>


### PR DESCRIPTION
KQEMU is obsolete and no longer supported in modern versions of QEMU. On the other hand, "info kvm" is a handy command to have these days.