### PR TITLE
Add ACPI shutdown to emulator control menu

### DIFF
--- a/resources/translations/English.ts
+++ b/resources/translations/English.ts
@@ -3228,12 +3228,17 @@ Linux Compressed Loop image, useful only to reuse directly compressed CD-ROM ima
     </message>
     <message>
         <location filename="Emulator_Control_Window.cpp" line="350"/>
-        <source>Are you sure to shutdown VM &quot;%1&quot;?</source>
+        <source>Are you sure you want to shutdown VM &quot;%1&quot;?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="Emulator_Control_Window.cpp" line="350"/>
+        <source>Are you sure you want to poweroff VM &quot;%1&quot;?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="Emulator_Control_Window.cpp" line="362"/>
-        <source>Are you sure to reboot VM &quot;%1&quot;?</source>
+        <source>Are you sure you want to reset VM &quot;%1&quot;?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/resources/translations/English.ts
+++ b/resources/translations/English.ts
@@ -5945,8 +5945,13 @@ The work of the VM is not possible!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="Main_Window.cpp" line="4862"/>
+        <source>Poweroff VM &quot;%1&quot;?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="Main_Window.cpp" line="4901"/>
-        <source>Reboot VM &quot;%1&quot;?</source>
+        <source>Reset VM &quot;%1&quot;?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/resources/translations/French.ts
+++ b/resources/translations/French.ts
@@ -6007,9 +6007,14 @@ The work of the VM is not possible!</source>
         <translation>Éteindre la VM « %1 » ?</translation>
     </message>
     <message>
+        <location filename="Main_Window.cpp" line="4862"/>
+        <source>Poweroff VM &quot;%1&quot;?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="Main_Window.cpp" line="4901"/>
-        <source>Reboot VM &quot;%1&quot;?</source>
-        <translation>Redémarrer la VM « %1 » ?</translation>
+        <source>Reset VM &quot;%1&quot;?</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="Main_Window.cpp" line="4912"/>

--- a/resources/translations/French.ts
+++ b/resources/translations/French.ts
@@ -3283,13 +3283,18 @@ Linux Compressed Loop image, useful only to reuse directly compressed CD-ROM ima
     </message>
     <message>
         <location filename="Emulator_Control_Window.cpp" line="350"/>
-        <source>Are you sure to shutdown VM &quot;%1&quot;?</source>
+        <source>Are you sure you want to shutdown VM &quot;%1&quot;?</source>
         <translation>Êtes-vous sûr de vouloir éteindre la VM « %1 » ?</translation>
     </message>
     <message>
+        <location filename="Emulator_Control_Window.cpp" line="350"/>
+        <source>Are you sure you want to poweroff VM &quot;%1&quot;?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="Emulator_Control_Window.cpp" line="362"/>
-        <source>Are you sure to reboot VM &quot;%1&quot;?</source>
-        <translation>Êtes-vous sûr de vouloir redémarrer la VM « %1 » ?</translation>
+        <source>Are you sure you want to reset VM &quot;%1&quot;?</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="Emulator_Control_Window.cpp" line="408"/>

--- a/resources/translations/German.ts
+++ b/resources/translations/German.ts
@@ -3598,8 +3598,14 @@ Do you want to show this message again?</source>
         <translation type="obsolete">VM &quot;%1&quot; herunterfahren?</translation>
     </message>
     <message>
-        <source>Reboot VM &quot;%1&quot;?</source>
-        <translation type="obsolete">VМ &quot;%1&quot; neu starten?</translation>
+        <location filename="Main_Window.cpp" line="4862"/>
+        <source>Poweroff VM &quot;%1&quot;?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="Main_Window.cpp" line="4901"/>
+        <source>Reset VM &quot;%1&quot;?</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="Emulator_Control_Window.cpp" line="87"/>

--- a/resources/translations/German.ts
+++ b/resources/translations/German.ts
@@ -3466,12 +3466,17 @@ Linux Compressed Loop image, useful only to reuse directly compressed CD-ROM ima
     </message>
     <message>
         <location filename="Emulator_Control_Window.cpp" line="350"/>
-        <source>Are you sure to shutdown VM &quot;%1&quot;?</source>
+        <source>Are you sure you want to shutdown VM &quot;%1&quot;?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="Emulator_Control_Window.cpp" line="350"/>
+        <source>Are you sure you want to poweroff VM &quot;%1&quot;?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="Emulator_Control_Window.cpp" line="362"/>
-        <source>Are you sure to reboot VM &quot;%1&quot;?</source>
+        <source>Are you sure you want to reset VM &quot;%1&quot;?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/resources/translations/Russian.ts
+++ b/resources/translations/Russian.ts
@@ -3462,13 +3462,18 @@ Linux Compressed Loop image, useful only to reuse directly compressed CD-ROM ima
     </message>
     <message>
         <location filename="Emulator_Control_Window.cpp" line="350"/>
-        <source>Are you sure to shutdown VM &quot;%1&quot;?</source>
+        <source>Are you sure you want to shutdown VM &quot;%1&quot;?</source>
         <translation>Выключить ВМ &quot;%1&quot;?</translation>
     </message>
     <message>
+        <location filename="Emulator_Control_Window.cpp" line="350"/>
+        <source>Are you sure you want to poweroff VM &quot;%1&quot;?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="Emulator_Control_Window.cpp" line="362"/>
-        <source>Are you sure to reboot VM &quot;%1&quot;?</source>
-        <translation>Перезагрузить ВМ &quot;%1&quot;?</translation>
+        <source>Are you sure you want to reset VM &quot;%1&quot;?</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="Emulator_Control_Window.cpp" line="592"/>

--- a/resources/translations/Russian.ts
+++ b/resources/translations/Russian.ts
@@ -3595,8 +3595,14 @@ Do you want to show this message again?</source>
         <translation type="obsolete">Выключить ВМ &quot;%1&quot;?</translation>
     </message>
     <message>
-        <source>Reboot VM &quot;%1&quot;?</source>
-        <translation type="obsolete">Перезагрузить ВМ &quot;%1&quot;?</translation>
+        <location filename="Main_Window.cpp" line="4862"/>
+        <source>Poweroff VM &quot;%1&quot;?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="Main_Window.cpp" line="4901"/>
+        <source>Reset VM &quot;%1&quot;?</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="Emulator_Control_Window.cpp" line="87"/>
@@ -6120,11 +6126,6 @@ The work of the VM is not possible!</source>
         <location filename="Main_Window.cpp" line="4862"/>
         <source>Shutdown VM &quot;%1&quot;?</source>
         <translation>Выключить ВМ &quot;%1&quot;?</translation>
-    </message>
-    <message>
-        <location filename="Main_Window.cpp" line="4901"/>
-        <source>Reboot VM &quot;%1&quot;?</source>
-        <translation>Перезагрузить ВМ &quot;%1&quot;?</translation>
     </message>
     <message>
         <location filename="Main_Window.cpp" line="5895"/>

--- a/resources/translations/Ukrainian.ts
+++ b/resources/translations/Ukrainian.ts
@@ -6049,8 +6049,13 @@ Add This Record?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="Main_Window.cpp" line="4862"/>
+        <source>Poweroff VM &quot;%1&quot;?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="Main_Window.cpp" line="4901"/>
-        <source>Reboot VM &quot;%1&quot;?</source>
+        <source>Reset VM &quot;%1&quot;?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/resources/translations/Ukrainian.ts
+++ b/resources/translations/Ukrainian.ts
@@ -3268,12 +3268,17 @@ Linux Compressed Loop image, useful only to reuse directly compressed CD-ROM ima
     </message>
     <message>
         <location filename="Emulator_Control_Window.cpp" line="350"/>
-        <source>Are you sure to shutdown VM &quot;%1&quot;?</source>
+        <source>Are you sure you want to shutdown VM &quot;%1&quot;?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="Emulator_Control_Window.cpp" line="350"/>
+        <source>Are you sure you want to poweroff VM &quot;%1&quot;?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="Emulator_Control_Window.cpp" line="362"/>
-        <source>Are you sure to reboot VM &quot;%1&quot;?</source>
+        <source>Are you sure you want to reset VM &quot;%1&quot;?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src/Emulator_Control_Window.cpp
+++ b/src/Emulator_Control_Window.cpp
@@ -770,10 +770,22 @@ void Emulator_Control_Window::on_actionPause_VM_triggered()
     AQEMU_Service::get().call("pause",Cur_VM);
 }
 
+void Emulator_Control_Window::on_actionShutdown_triggered()
+{
+	if ( QMessageBox::question(this, tr("Are you sure?"),
+		 tr("Are you sure you want to shutdown VM \"%1\"?").arg(Cur_VM->Get_Machine_Name()),
+		 QMessageBox::Yes | QMessageBox::No, QMessageBox::Yes) == QMessageBox::No)
+	{
+		return;
+	}
+
+	AQEMU_Service::get().call("shutdown",Cur_VM);
+}
+
 void Emulator_Control_Window::on_actionPower_Off_triggered()
 {
 	if( QMessageBox::question(this, tr("Are you sure?"),
-		tr("Are you sure to shutdown VM \"%1\"?").arg(Cur_VM->Get_Machine_Name()),
+		tr("Are you sure you want to poweroff VM \"%1\"?").arg(Cur_VM->Get_Machine_Name()),
 		QMessageBox::Yes | QMessageBox::No, QMessageBox::Yes) == QMessageBox::No )
 	{
 		return;
@@ -785,7 +797,7 @@ void Emulator_Control_Window::on_actionPower_Off_triggered()
 void Emulator_Control_Window::on_actionReset_VM_triggered()
 {
 	if( QMessageBox::question(this, tr("Are you sure?"),
-		tr("Are you sure to reboot VM \"%1\"?").arg(Cur_VM->Get_Machine_Name()),
+		tr("Are you sure you want to reset VM \"%1\"?").arg(Cur_VM->Get_Machine_Name()),
 		QMessageBox::Yes | QMessageBox::No, QMessageBox::Yes) == QMessageBox::No )
 	{
 		return;

--- a/src/Emulator_Control_Window.h
+++ b/src/Emulator_Control_Window.h
@@ -73,6 +73,7 @@ class Emulator_Control_Window: public QMainWindow
 		void on_actionManage_Snapshots_triggered();
 		void on_actionCommit_triggered();
 		void on_actionPause_VM_triggered();
+		void on_actionShutdown_triggered();
 		void on_actionPower_Off_triggered();
 		void on_actionReset_VM_triggered();
 		void on_actionQEMU_Monitor_triggered();

--- a/src/Emulator_Control_Window.ui
+++ b/src/Emulator_Control_Window.ui
@@ -58,6 +58,7 @@
     <addaction name="actionCommit"/>
     <addaction name="separator"/>
     <addaction name="actionPause_VM"/>
+    <addaction name="actionShutdown"/>
     <addaction name="actionPower_Off"/>
     <addaction name="actionReset_VM"/>
     <addaction name="separator"/>
@@ -652,6 +653,15 @@
    </property>
    <property name="text">
     <string>&amp;Grab Mouse</string>
+   </property>
+  </action>
+  <action name="actionShutdown">
+   <property name="icon">
+    <iconset resource="../resources/icons.qrc">
+     <normaloff>:/shutdown.png</normaloff>:/shutdown.png</iconset>
+   </property>
+   <property name="text">
+    <string>Shut&amp;down</string>
    </property>
   </action>
  </widget>

--- a/src/Main_Window.cpp
+++ b/src/Main_Window.cpp
@@ -3358,7 +3358,7 @@ void Main_Window::on_actionPower_Off_triggered()
 	}
 
 	if( QMessageBox::question(this, tr("Are you sure?"),
-		tr("Shutdown VM \"%1\"?").arg(cur_vm->Get_Machine_Name()),
+		tr("Poweroff VM \"%1\"?").arg(cur_vm->Get_Machine_Name()),
 		QMessageBox::Yes | QMessageBox::No, QMessageBox::Yes) == QMessageBox::No )
 	{
 		return;
@@ -3420,7 +3420,7 @@ void Main_Window::on_actionReset_triggered()
 	}
 
 	if( QMessageBox::question(this, tr("Are you sure?"),
-		tr("Reboot VM \"%1\"?").arg(cur_vm->Get_Machine_Name()),
+		tr("Reset VM \"%1\"?").arg(cur_vm->Get_Machine_Name()),
 		QMessageBox::Yes | QMessageBox::No, QMessageBox::Yes) == QMessageBox::No )
 	{
 		return;


### PR DESCRIPTION
Adds an item to the emulator control menu to send an ACPI shutdown signal to a VM, thus allowing it to gracefully shut down.

Also changes the existing wording from shutdown/reboot -> poweroff/reset, to clarify the forcible nature of those operations.